### PR TITLE
Don't pin cli base image to an arch-specific hash

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.15.0@sha256:c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060 AS base
+#FROM alpine:3.15.0@sha256:c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060 AS base
+FROM docker.io/alpine:3.15.0 AS base
 
 RUN apk add --update --no-cache \
 	nodejs~=16 \


### PR DESCRIPTION
c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060 seems to be an arm-specific image:

https://hub.docker.com/layers/arm64v8/alpine/3.15.0/images/sha256-c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060

Pin by tag instead to allow building for amd64 etc.